### PR TITLE
Allow to disable autofocus.

### DIFF
--- a/src/components/term.js
+++ b/src/components/term.js
@@ -18,16 +18,17 @@ class Term extends React.Component {
   }
 
   componentDidMount() {
+    const { autoFocus } = this.props;
     this.props.initFilesystem(root);
-    this.prompt && this.prompt.focus();
+    autoFocus && this.prompt && this.prompt.focus();
   }
 
   componentDidUpdate() {
-    const { maxHeight } = this.props;
+    const { maxHeight, autoFocus } = this.props;
     const height = this.term.scrollHeight > maxHeight ? maxHeight : this.term.scrollHeight;
     this.term.style.height = `${height}px`;
     this.term.scrollTop = this.term.scrollHeight;
-    this.prompt && this.prompt.focus();
+    autoFocus && this.prompt && this.prompt.focus();
   }
 
   startRecording() {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ if (window.$) {
     (_, el) => {
       render((
         <Provider store={store}>
-          <Term maxHeight={window.$(el).data('maxHeight') || 600} autoFocus={window.$(el).data('autoFocus') || true}/>
+          <Term maxHeight={window.$(el).data('max-height') || 600} autoFocus={window.$(el).data('auto-focus') || true}/>
         </Provider>
       ), el);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -26,17 +26,19 @@ store.dispatch(setConfig({
 }));
 
 function termProvider(maxHeight, autoFocus) {
-  const setAutoFocus = autoFocus && autoFocus !== "false";
-
   return <Provider store={store}>
-    <Term maxHeight={maxHeight} autoFocus={setAutoFocus}/>
+    <Term maxHeight={maxHeight} autoFocus={autoFocus}/>
   </Provider>;
 }
 
 if (window.$) {
   window.$('.js-terminal').each(
     (_, el) => {
-      render(termProvider(window.$(el).data('max-height') || 600, window.$(el).data('auto-focus') || true), el);
+      const jElement = window.$(el);
+      const autoFocus = jElement.data('auto-focus') !== undefined ? jElement.data('auto-focus') : true;
+      const maxWidth = jElement.data('max-height') || 600;
+
+      render(termProvider(maxWidth, autoFocus), el);
     }
   );
 } else {

--- a/src/index.js
+++ b/src/index.js
@@ -25,20 +25,20 @@ store.dispatch(setConfig({
   logger: window.TUTORIAL_LOG_ENDPOINT
 }));
 
+function termProvider(maxHeight, autoFocus) {
+  const setAutoFocus = autoFocus && autoFocus !== "false";
+
+  return <Provider store={store}>
+    <Term maxHeight={maxHeight} autoFocus={setAutoFocus}/>
+  </Provider>;
+}
+
 if (window.$) {
   window.$('.js-terminal').each(
     (_, el) => {
-      render((
-        <Provider store={store}>
-          <Term maxHeight={window.$(el).data('max-height') || 600} autoFocus={window.$(el).data('auto-focus') || true}/>
-        </Provider>
-      ), el);
+      render(termProvider(window.$(el).data('max-height') || 600, window.$(el).data('auto-focus') || true), el);
     }
   );
 } else {
-  render((
-    <Provider store={store}>
-      <Term maxHeight={600} autoFocus={true}/>
-    </Provider>
-  ), document.getElementById('root'));
+  render(termProvider(600, true), document.getElementById('root'));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ if (window.$) {
     (_, el) => {
       render((
         <Provider store={store}>
-          <Term maxHeight={window.$(el).data('maxHeight') || 600}/>
+          <Term maxHeight={window.$(el).data('maxHeight') || 600} autoFocus={window.$(el).data('autoFocus') || true}/>
         </Provider>
       ), el);
     }
@@ -38,7 +38,7 @@ if (window.$) {
 } else {
   render((
     <Provider store={store}>
-      <Term maxHeight={600}/>
+      <Term maxHeight={600} autoFocus={true}/>
     </Provider>
   ), document.getElementById('root'));
 }


### PR DESCRIPTION
So pages with the terminal below the fold don't scroll all the way to
it, hiding the header.

Signed-off-by: David Calavera david.calavera@gmail.com
